### PR TITLE
[Feature]Add missing associated user data to the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Added
+
+- Provide user data via Koa Session
 
 ## [3.1.70] - 2020-09-08
 

--- a/src/auth/create-oauth-callback.ts
+++ b/src/auth/create-oauth-callback.ts
@@ -53,11 +53,17 @@ export default function createOAuthCallback(config: AuthConfig) {
     }
 
     const accessTokenData = await accessTokenResponse.json();
-    const {access_token: accessToken} = accessTokenData;
+    const {
+      access_token: accessToken,
+      associated_user_scope: associatedUserScope,
+      associated_user: associatedUser,
+    } = accessTokenData;
 
     if (ctx.session) {
       ctx.session.shop = shop;
       ctx.session.accessToken = accessToken;
+      ctx.session.associatedUserScope = associatedUserScope;
+      ctx.session.associatedUser = associatedUser;
     }
 
     ctx.state.shopify = {


### PR DESCRIPTION
### WHY are these changes introduced?
I wanted to get associatedUserId after user authentification using koa-shopiy-auth, but I could not find it in the session.
A lot of Shopify App beginner-developers (including me) use this approach for user authentification, because Shopify introduces that way in the [tutorial](https://shopify.dev/tutorials/build-a-shopify-app-with-node-and-react). 

Also, this is same as this PR https://github.com/Shopify/quilt/pull/1542 .

### WHAT is this pull request doing?

Add associated user data and scope to the session.

This is particularly useful for determining the currently authenticated user in [online access mode](https://shopify.dev/concepts/about-apis/authentication#api-access-modes).

See also: [Authenticate With OAuth Docs](https://shopify.dev/tutorials/authenticate-with-oauth#step-3-confirm-installation)

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
