### PR TITLE
Add the ability to specify the host of the redirect url instead of ctx.host

### DIFF
--- a/src/auth/create-top-level-redirect.ts
+++ b/src/auth/create-top-level-redirect.ts
@@ -3,10 +3,12 @@ import querystring from 'querystring';
 import {Context} from 'koa';
 
 import redirectionPage from './redirection-page';
+import getHost from './../lib/get-host';
 
 export default function createTopLevelRedirect(apiKey: string, path: string) {
   return function topLevelRedirect(ctx: Context) {
-    const {host, query} = ctx;
+    const host = getHost(ctx);
+    const {query} = ctx;
     const {shop} = query;
 
     const params = {shop};

--- a/src/auth/oauth-query-string.ts
+++ b/src/auth/oauth-query-string.ts
@@ -6,6 +6,7 @@ import nonce from 'nonce';
 import {OAuthStartOptions} from '../types';
 
 import getCookieOptions from './cookie-options';
+import getHost from './../lib/get-host';
 
 const createNonce = nonce();
 
@@ -14,7 +15,8 @@ export default function oAuthQueryString(
   options: OAuthStartOptions,
   callbackPath: string,
 ) {
-  const {host, cookies} = ctx;
+  const host = getHost(ctx);
+  const {cookies} = ctx;
   const {scopes = [], apiKey, accessMode} = options;
 
   const requestNonce = createNonce();

--- a/src/lib/get-host.ts
+++ b/src/lib/get-host.ts
@@ -1,0 +1,8 @@
+import { Context } from 'koa';
+
+export default function getHost(ctx: Context) {
+    const {
+        SHOPIFY_APP_HOST
+    } = process.env;
+    return SHOPIFY_APP_HOST || ctx.host;
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
I am facing a problem were the redirect URL is having the backend host as its host because of the reverse proxy on my server and thus having to whitelist this URI and face cookies problem or having to edit the proxy behavior to add the X-Forwarded-Host.

Fixes #11 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
It adds the ability to specify the host of the redirect url using `SHOPIFY_APP_HOST` environment variable instead of ctx.host
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
