### PR TITLE
➖ Remove the need for external safe compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Removed
+
+- Removes `safe-compare` as a dependency, preferring Node's `crypto.timingSafeEqual` [1470](https://github.com/Shopify/quilt/pull/1470)
 
 ## [3.1.70] - 2020-09-08
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@shopify/network": "^1.5.0",
     "koa-compose": ">=3.0.0 <4.0.0",
     "nonce": "^1.0.4",
-    "safe-compare": "^1.1.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -35,7 +34,7 @@
     "@shopify/jest-koa-mocks": "^2.2.3",
     "@types/koa": "^2.0.0",
     "@types/koa-compose": "*",
-    "@types/safe-compare": "^1.1.0",
+    "@types/node": "^14.11.2",
     "babel-preset-shopify": "^21.0.0",
     "eslint": "^7.8.1",
     "jest": "^26.4.2",

--- a/src/auth/safe-compare.ts
+++ b/src/auth/safe-compare.ts
@@ -15,5 +15,5 @@ export default function safeCompare(stringA: string, stringB: string) {
     const buffB = Buffer.alloc(bLen, 0, 'utf8');
     buffB.write(stringB);
 
-    return crypto.timingSafeEqual(buffA, buffB) && aLen === bLen;
+    return crypto.timingSafeEqual(buffA, buffB);
 }

--- a/src/auth/safe-compare.ts
+++ b/src/auth/safe-compare.ts
@@ -4,11 +4,15 @@ export default function safeCompare(stringA: string, stringB: string) {
     const aLen = Buffer.byteLength(stringA);
     const bLen = Buffer.byteLength(stringB);
 
+    if (aLen !== bLen) {
+        return false
+    }
+
     // Turn strings into buffers with equal length
     // to avoid leaking the length
     const buffA = Buffer.alloc(aLen, 0, 'utf8');
     buffA.write(stringA);
-    const buffB = Buffer.alloc(aLen, 0, 'utf8');
+    const buffB = Buffer.alloc(bLen, 0, 'utf8');
     buffB.write(stringB);
 
     return crypto.timingSafeEqual(buffA, buffB) && aLen === bLen;

--- a/src/auth/safe-compare.ts
+++ b/src/auth/safe-compare.ts
@@ -1,0 +1,15 @@
+import crypto from 'crypto';
+
+export default function safeCompare(stringA: string, stringB: string) {
+    const aLen = Buffer.byteLength(stringA);
+    const bLen = Buffer.byteLength(stringB);
+
+    // Turn strings into buffers with equal length
+    // to avoid leaking the length
+    const buffA = Buffer.alloc(aLen, 0, 'utf8');
+    buffA.write(stringA);
+    const buffB = Buffer.alloc(aLen, 0, 'utf8');
+    buffB.write(stringB);
+
+    return crypto.timingSafeEqual(buffA, buffB) && aLen === bLen;
+}

--- a/src/auth/test/safe-compare.test.ts
+++ b/src/auth/test/safe-compare.test.ts
@@ -1,0 +1,13 @@
+import safeCompare from '../safe-compare'
+
+const hmac = '7c66606415117ff9744a2a9b2be1712a15928b5ef474ab1a9ff5dc36b7dcaed8';
+
+describe('safeCompare', () => {
+  it('returns true when values are the same', () => {
+    expect(safeCompare(hmac, hmac)).toBe(true);
+  });
+
+  it('returns false when values are different', () => {
+    expect(safeCompare(hmac, 'not hmac')).toBe(false);
+  });
+});

--- a/src/auth/test/validate-hmac.test.ts
+++ b/src/auth/test/validate-hmac.test.ts
@@ -1,10 +1,10 @@
 import validateHmac from '../validate-hmac';
 
-jest.mock('safe-compare', () => {
+jest.mock('../safe-compare', () => {
   return jest.fn((first: string, second: string) => first === second);
 });
 
-const safeCompare = jest.requireMock('safe-compare');
+const safeCompare = jest.requireMock('../safe-compare');
 const data = {fiz: 'buzz', foo: 'bar'};
 const secret = 'some secret';
 const hmac = '7c66606415117ff9744a2a9b2be1712a15928b5ef474ab1a9ff5dc36b7dcaed8';

--- a/src/auth/validate-hmac.ts
+++ b/src/auth/validate-hmac.ts
@@ -2,7 +2,7 @@ import querystring from 'querystring';
 import crypto from 'crypto';
 
 import {Context} from 'koa';
-import safeCompare from 'safe-compare';
+import safeCompare from './safe-compare';
 
 export default function validateHmac(
   hmac: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
   integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
+"@types/node@^14.11.2":
+  version "14.11.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
+  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -1448,11 +1453,6 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
-
-"@types/safe-compare@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/safe-compare/-/safe-compare-1.1.0.tgz#47ed9b9ca51a3a791b431cd59b28f47fa9bf1224"
-  integrity sha512-1ri+LJhh0gRxIa37IpGytdaW7yDEHeJniBSMD1BmitS07R1j63brcYCzry+l0WJvGdEKQNQ7DYXO2epgborWPw==
 
 "@types/serve-static@*":
   version "1.13.5"
@@ -1857,24 +1857,6 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
-
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -4668,13 +4650,6 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-compare@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/safe-compare/-/safe-compare-1.1.4.tgz#5e0128538a82820e2e9250cd78e45da6786ba593"
-  integrity sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==
-  dependencies:
-    buffer-alloc "^1.2.0"
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Description

Fixes #2 

The `safe-compare` was an unneeded external dependency. This PR removes it and adds a file to do it without new deps.

To test locally I built a new Shopify App and [started a local dev server](https://github.com/Shopify/quilt/tree/master/packages/koa-shopify-auth#example-app). I was able to install the app on my test store.

## Type of change

<!--
If this pull request changes multiple packages, please indicate the type of change for each package.

If this is a new package, you may disregard this section.

Please delete options that are not relevant.
-->

- [ ] <!--Package Name--> Patch: Bug/ Documentation fix (non-breaking change which fixes an issue or adds documentation)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above