### PR TITLE
Fix inconsistency in authentication path prefix to remove trailing slash  

### DIFF
--- a/src/auth/client/request-storage-access.ts
+++ b/src/auth/client/request-storage-access.ts
@@ -1,16 +1,16 @@
 // Copied from https://github.com/Shopify/shopify_app
-const requestStorageAccess = (shop: string, prefix = '/') => {
+const requestStorageAccess = (shop: string, prefix = '') => {
   return `(function() {
       function redirect() {
         var targetInfo = {
           myshopifyUrl: "https://${encodeURIComponent(shop)}",
-          hasStorageAccessUrl: "${prefix}auth/inline?shop=${encodeURIComponent(
+          hasStorageAccessUrl: "${prefix}/auth/inline?shop=${encodeURIComponent(
     shop,
   )}",
-          doesNotHaveStorageAccessUrl: "${prefix}auth/enable_cookies?shop=${encodeURIComponent(
+          doesNotHaveStorageAccessUrl: "${prefix}/auth/enable_cookies?shop=${encodeURIComponent(
     shop,
   )}",
-          appTargetUrl: "${prefix}?shop=${encodeURIComponent(shop)}"
+          appTargetUrl: "${prefix}/?shop=${encodeURIComponent(shop)}"
         }
 
         if (window.top == window.self) {


### PR DESCRIPTION
### WHY are these changes introduced?

There are inconsistent assumptions around whether the authentication middleware should use a trailing slash in the prefix.  The `createShopifyAuth` function assumes no trailing slash, but `requestStorageAccess` assumes trailing slash.  This leads to a 404 error when `requestStorageAccess` attempts to access a url in the form: `customprefixauth/inline?shop=`.  Note the missing slash between `customprefix` and `auth/`.

### WHAT is this pull request doing?

Update the `requestStorageAccess` function to assume no trailing slash in the prefix. 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
