### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ app.use(
     secret: SHOPIFY_SECRET,
     // scopes to request on the merchants store
     scopes: ['write_orders, write_products'],
-    // set access mode, default is 'online'
+    // set access mode, default is 'offline'
     accessMode: 'offline',
     // callback for when auth is completed
     afterAuth(ctx) {


### PR DESCRIPTION
According to `https://shopify.dev/tutorials/authenticate-with-oauth#step-2-ask-for-permission` the default access mode is `offline`