### PR TITLE
Rename middleware intializer export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ export default shopifyAuth;
 
 export * from './auth';
 
-export {default as initializeShopifyKoa} from './init';
+export {default as initializeShopifyKoaMiddleware} from './init';
 
 export {default as verifyRequest} from './verify-request';


### PR DESCRIPTION
### WHY are these changes introduced?

The previous name of the middleware initialization method we exported wasn't very clear, so this PR renames it. This method may not be needed in the end but if it stays it should have a good name.

### WHAT is this pull request doing?

Going from `initializeShopifyKoa` to `initializeShopifyKoaMiddleware` to make exactly what this method does clearer.
