### PR TITLE
Check for scope changes in verifyRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Shopify/koa-shopify-auth/README.md",
   "dependencies": {
     "@shopify/network": "^1.5.0",
-    "@shopify/shopify-api": "^0.4.0",
+    "@shopify/shopify-api": "^0.5.0",
     "koa-compose": ">=3.0.0 <4.0.0",
     "nonce": "^1.0.4",
     "tslib": "^1.9.3"

--- a/src/verify-request/verify-token.ts
+++ b/src/verify-request/verify-token.ts
@@ -17,10 +17,14 @@ export function verifyToken(routes: Routes) {
     let session: Session | undefined;
     session = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res);
 
-    if (session?.accessToken && (!session?.expires || session?.expires >= new Date())) {
-      ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
-      await next();
-      return;
+    if (session) {
+      const scopesChanged = !Shopify.Context.SCOPES.equals(session.scope);
+
+      if (!scopesChanged && session.accessToken && (!session.expires || session.expires >= new Date())) {
+        ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
+        await next();
+        return;
+      }
     }
 
     ctx.cookies.set(TEST_COOKIE_NAME, '1');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@
   dependencies:
     tslib "^1.14.1"
 
-"@shopify/shopify-api@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-0.4.0.tgz#86ff8f3b6bd0027d0da3f366407ca484729ed16a"
-  integrity sha512-Y/SYQObM36jiryCfO1t891A3m1P0uGXbA3gVbQdu2NU+i5z2ClMd82JOU0mG8IaUXjMoAorcy0hET+cFyJq/qQ==
+"@shopify/shopify-api@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-0.5.0.tgz#470e67a4b4c862882a3eefbe976b37b9585313ba"
+  integrity sha512-1INjqmUH9GP9M+2HjgvRHJO2RGxHrhzpIKvnoJP4ZCUbZgDjq/GLpOn+fhGGQDfVc7IkGK6ypIQXxW5Th7sZcg==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/jsonwebtoken" "^8.5.0"


### PR DESCRIPTION
### WHY are these changes introduced?

The Shopify library now allows checking if a set of scopes doesn't match the current configuration. If that happens, we want merchants to go through OAuth again to update their scopes.

### WHAT is this pull request doing?

Checking if the session scopes are up to date, and redirecting the merchant to OAuth if they aren't.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
