### PR TITLE
Set the user agent for the Shopify library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Sets the `USER_AGENT_PREFIX` on `Shopify.Context` for usage tracking data. [55](https://github.com/Shopify/koa-shopify-auth/pull/55)
+
 ## [4.0.0] - 2021-02-25
 
 ### Added

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -6,6 +6,7 @@ import getCookieOptions from './cookie-options';
 import createEnableCookies from './create-enable-cookies';
 import createTopLevelOAuthRedirect from './create-top-level-oauth-redirect';
 import createRequestStorageAccess from './create-request-storage-access';
+import setUserAgent from './set-user-agent';
 
 import Shopify from '@shopify/shopify-api';
 
@@ -50,6 +51,8 @@ export default function createShopifyAuth(options: OAuthStartOptions) {
   const enableCookiesPath = `${oAuthStartPath}/enable_cookies`;
   const enableCookies = createEnableCookies(config);
   const requestStorageAccess = createRequestStorageAccess(config);
+
+  setUserAgent();
 
   return async function shopifyAuth(ctx: Context, next: NextFunction) {
     ctx.cookies.secure = true;

--- a/src/auth/set-user-agent.ts
+++ b/src/auth/set-user-agent.ts
@@ -1,0 +1,11 @@
+import Shopify from '@shopify/shopify-api';
+
+export const KOA_USER_AGENT_PREFIX = 'Koa Shopify Auth';
+
+export default function setUserAgent() {
+  if (!Shopify.Context.USER_AGENT_PREFIX) {
+    Shopify.Context.USER_AGENT_PREFIX = KOA_USER_AGENT_PREFIX;
+  } else if (!Shopify.Context.USER_AGENT_PREFIX.includes(KOA_USER_AGENT_PREFIX)) {
+    Shopify.Context.USER_AGENT_PREFIX = `${Shopify.Context.USER_AGENT_PREFIX} | ${KOA_USER_AGENT_PREFIX}`;
+  }
+}

--- a/src/auth/test/index.test.ts
+++ b/src/auth/test/index.test.ts
@@ -12,6 +12,7 @@ import crypto from 'crypto';
 import createShopifyAuth from '../index';
 import createTopLevelOAuthRedirect from '../create-top-level-oauth-redirect';
 import {OAuthStartOptions} from '../../types';
+import {KOA_USER_AGENT_PREFIX} from '../set-user-agent';
 
 const mockTopLevelOAuthRedirect = jest.fn();
 jest.mock('../create-top-level-oauth-redirect', () =>
@@ -239,5 +240,12 @@ describe('Index', () => {
 
       expect(mockEnableCookies).toHaveBeenCalledWith(ctx);
     });
+  });
+
+  it('always sets the user agent prefix', () => {
+    expect(Shopify.Context.USER_AGENT_PREFIX).toBeUndefined();
+
+    const shopifyAuth = createShopifyAuth(baseConfig);
+    expect(Shopify.Context.USER_AGENT_PREFIX).toEqual(KOA_USER_AGENT_PREFIX);
   });
 });

--- a/src/auth/test/set-user-agent.test.ts
+++ b/src/auth/test/set-user-agent.test.ts
@@ -1,0 +1,30 @@
+import '../../test/test_helper';
+
+import Shopify from '@shopify/shopify-api';
+import setUserAgent, {KOA_USER_AGENT_PREFIX} from '../set-user-agent';
+
+describe('setUserAgent', () => {
+  it('sets the user agent if it is empty', () => {
+    expect(Shopify.Context.USER_AGENT_PREFIX).toBeUndefined();
+
+    setUserAgent();
+    expect(Shopify.Context.USER_AGENT_PREFIX).toEqual(KOA_USER_AGENT_PREFIX);
+
+    setUserAgent();
+    expect(Shopify.Context.USER_AGENT_PREFIX).toEqual(KOA_USER_AGENT_PREFIX);
+  });
+
+  it('sets the user agent if it is set', () => {
+    expect(Shopify.Context.USER_AGENT_PREFIX).toBeUndefined();
+
+    const testPrefix = 'Test user agent';
+    Shopify.Context.USER_AGENT_PREFIX = testPrefix;
+    Shopify.Context.initialize(Shopify.Context);
+
+    setUserAgent();
+    expect(Shopify.Context.USER_AGENT_PREFIX).toEqual(`${testPrefix} | ${KOA_USER_AGENT_PREFIX}`);
+
+    setUserAgent();
+    expect(Shopify.Context.USER_AGENT_PREFIX).toEqual(`${testPrefix} | ${KOA_USER_AGENT_PREFIX}`);
+  });
+});

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -12,4 +12,5 @@ beforeEach(() => {
     IS_EMBEDDED_APP: true,
     SESSION_STORAGE: new MemorySessionStorage(),
   });
+  Shopify.Context.USER_AGENT_PREFIX = undefined;
 });


### PR DESCRIPTION
### WHY are these changes introduced?

The new library allows us to set a specific user agent for calls made using this package, which allows us to tell requests apart from 'pure' library ones.

### WHAT is this pull request doing?

It creates a function that makes sure the user agent is set. This function can be called multiple times without messing up the agent, so we are able to call it in multiple entrypoints to this package.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
