### PR TITLE
Allow offline sessions in the middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Ensure both `shopifyAuth` and `verifyRequest` work in offline mode. [59](https://github.com/Shopify/koa-shopify-auth/pull/59)
+
 ## [4.0.1] - 2021-02-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ app.use(
     // path to redirect to if verification fails and there is no shop on the query
     // defaults to '/auth'
     fallbackRoute: '/install',
+    // which access mode is being used
+    // defaults to 'online'
+    accessMode: 'offline',
   }),
 );
 ```
@@ -102,8 +105,9 @@ If you have an app using this package, you can migrate from cookie-based authent
 
 - Upgrade your `@shopify/koa-shopify-auth` dependency to v4+
 - Update your server as per the [Usage](#usage) instructions to properly initialize the `@shopify/shopify-api` library
+- If you are using `accessMode: 'offline'` in `shopifyAuth`, make sure to pass the same value in `verifyRequest`
 - Install `@shopify/app-bridge-utils` in your frontend app
-- In your frontend app, replace `fetch` calls with `authenticatedFetch` from App Bridge
+- In your frontend app, replace `fetch` calls with `authenticatedFetch` from App Bridge Utils
 
 **Note**: the backend steps need to be performed to fully migrate your app to v4, even if your app is not embedded.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Shopify/koa-shopify-auth/blob/master/README.md",
   "dependencies": {
     "@shopify/network": "^1.5.0",
-    "@shopify/shopify-api": "^1.0.0",
+    "@shopify/shopify-api": "^1.1.0",
     "koa-compose": ">=3.0.0 <4.0.0",
     "nonce": "^1.0.4",
     "tslib": "^1.9.3"
@@ -38,7 +38,7 @@
     "@types/jest": "^26.0.20",
     "@types/koa": "^2.0.0",
     "@types/koa-compose": "*",
-    "@types/node": "^14.14.20",
+    "@types/node": "^14.14.31",
     "babel-preset-shopify": "^21.0.0",
     "eslint": "^7.8.1",
     "jest": "^26.4.2",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -11,7 +11,7 @@ import setUserAgent from './set-user-agent';
 import Shopify from '@shopify/shopify-api';
 
 const DEFAULT_MYSHOPIFY_DOMAIN = 'myshopify.com';
-const DEFAULT_ACCESS_MODE: AccessMode = 'online';
+export const DEFAULT_ACCESS_MODE: AccessMode = 'online';
 
 export const TOP_LEVEL_OAUTH_COOKIE_NAME = 'shopifyTopLevelOAuth';
 export const TEST_COOKIE_NAME = 'shopifyTestCookie';
@@ -96,7 +96,7 @@ export default function createShopifyAuth(options: OAuthStartOptions) {
       try {
         await Shopify.Auth.validateAuthCallback(ctx.req, ctx.res, ctx.query);
 
-        ctx.state.shopify = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res);
+        ctx.state.shopify = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res, config.accessMode === 'online');
 
         if (config.afterAuth) {
           await config.afterAuth(ctx);

--- a/src/auth/test/index.test.ts
+++ b/src/auth/test/index.test.ts
@@ -166,6 +166,19 @@ describe('Index', () => {
       expect(ctx.state.shopify.shop).toEqual(shop);
     });
 
+    it('performs oauth callback with offline sessions', async () => {
+      let ctx = createMockContext({
+        url: `${baseCallbackUrl}?${querystring.stringify(queryData)}`,
+        throw: jest.fn(),
+      });
+
+      const shopifyAuth = createShopifyAuth({...baseConfig, accessMode: 'offline'});
+      await shopifyAuth(ctx, nextFunction);
+
+      expect(ctx.throw).not.toHaveBeenCalled();
+      expect(ctx.state.shopify.shop).toEqual(shop);
+    });
+
     it('calls afterAuth with ctx when the token request succeeds', async () => {
       const afterAuth = jest.fn();
 

--- a/src/verify-request/login-again-if-different-shop.ts
+++ b/src/verify-request/login-again-if-different-shop.ts
@@ -3,22 +3,23 @@ import {Context} from 'koa';
 import Shopify from '@shopify/shopify-api';
 import { Session } from '@shopify/shopify-api/dist/auth/session';
 
-import {NextFunction} from '../types';
+import {AccessMode, NextFunction} from '../types';
 
 import {Routes} from './types';
 import {clearSession, redirectToAuth} from './utilities';
+import {DEFAULT_ACCESS_MODE} from '../auth';
 
-export function loginAgainIfDifferentShop(routes: Routes) {
+export function loginAgainIfDifferentShop(routes: Routes, accessMode: AccessMode = DEFAULT_ACCESS_MODE) {
   return async function loginAgainIfDifferentShopMiddleware(
     ctx: Context,
     next: NextFunction,
   ) {
     const {query} = ctx;
     let session: Session | undefined;
-    session = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res);
+    session = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res, accessMode === 'online');
 
     if (session && query.shop && session.shop !== query.shop) {
-      await clearSession(ctx);
+      await clearSession(ctx, accessMode);
       redirectToAuth(routes, ctx);
       return;
     }

--- a/src/verify-request/types.ts
+++ b/src/verify-request/types.ts
@@ -1,6 +1,12 @@
+import { AccessMode } from "src/types";
+
 export interface Routes {
   authRoute: string;
   fallbackRoute: string;
 }
 
-export type Options = Partial<Routes>;
+type VerifyRequestOptions = {
+  accessMode: AccessMode;
+}
+
+export type Options = Partial<VerifyRequestOptions> & Partial<Routes>;

--- a/src/verify-request/utilities.ts
+++ b/src/verify-request/utilities.ts
@@ -3,6 +3,8 @@ import {Context} from 'koa';
 import Shopify from '@shopify/shopify-api';
 
 import {Routes} from './types';
+import {AccessMode} from '../types';
+import {DEFAULT_ACCESS_MODE} from '../auth';
 
 export function redirectToAuth(
   {fallbackRoute, authRoute}: Routes,
@@ -18,9 +20,9 @@ export function redirectToAuth(
   ctx.redirect(routeForRedirect);
 }
 
-export async function clearSession(ctx: Context) {
+export async function clearSession(ctx: Context, accessMode: AccessMode = DEFAULT_ACCESS_MODE) {
   try {
-    await Shopify.Utils.deleteCurrentSession(ctx.req, ctx.res);
+    await Shopify.Utils.deleteCurrentSession(ctx.req, ctx.res, accessMode === 'online');
   }
   catch (error) {
     if (error instanceof Shopify.Errors.SessionNotFound) {

--- a/src/verify-request/verify-request.ts
+++ b/src/verify-request/verify-request.ts
@@ -3,13 +3,21 @@ import compose from 'koa-compose';
 import {loginAgainIfDifferentShop} from './login-again-if-different-shop';
 import {verifyToken} from './verify-token';
 import {Options, Routes} from './types';
+import {DEFAULT_ACCESS_MODE} from '../auth';
 
 export default function verifyRequest(givenOptions: Options = {}) {
+  const {accessMode} = {
+    accessMode: DEFAULT_ACCESS_MODE,
+    ...givenOptions
+  };
   const routes: Routes = {
     authRoute: '/auth',
     fallbackRoute: '/auth',
     ...givenOptions,
   };
 
-  return compose([loginAgainIfDifferentShop(routes), verifyToken(routes)]);
+  return compose([
+    loginAgainIfDifferentShop(routes, accessMode),
+    verifyToken(routes, accessMode)
+  ]);
 }

--- a/src/verify-request/verify-token.ts
+++ b/src/verify-request/verify-token.ts
@@ -3,19 +3,20 @@ import { Session } from '@shopify/shopify-api/dist/auth/session';
 
 import {Context} from 'koa';
 
-import {NextFunction} from '../types';
+import {AccessMode, NextFunction} from '../types';
 import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../index';
 
 import {Routes} from './types';
 import {redirectToAuth} from './utilities';
+import {DEFAULT_ACCESS_MODE} from '../auth';
 
-export function verifyToken(routes: Routes) {
+export function verifyToken(routes: Routes, accessMode: AccessMode = DEFAULT_ACCESS_MODE) {
   return async function verifyTokenMiddleware(
     ctx: Context,
     next: NextFunction,
   ) {
     let session: Session | undefined;
-    session = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res);
+    session = await Shopify.Utils.loadCurrentSession(ctx.req, ctx.res, accessMode === 'online');
 
     if (session) {
       const scopesChanged = !Shopify.Context.SCOPES.equals(session.scope);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,16 +1251,16 @@
     tslib "^1.9.3"
 
 "@shopify/network@^1.5.1":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@shopify/network/-/network-1.6.0.tgz#80605bd14ce0c5136ea1be90f38042396dbc547f"
-  integrity sha512-VT8277uw06VZRyPoOMXXQgpnxkwVTIQQkaO/t6pVSgr6prmyWj7qA7mEIjwb+TkTXrmrD10F3dPKpiqX87jYYg==
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@shopify/network/-/network-1.6.1.tgz#a3eea9bbea1da11a21aaf4b157053efd26a66905"
+  integrity sha512-VooupKHmBedFoNWGY2sg/xZ2jodGW0pcMsi5M83S0kHeJ0zNPUSOZb+PT2wPU6YO5XiYu7f1GwvtBK5qsAwWKw==
   dependencies:
     tslib "^1.14.1"
 
-"@shopify/shopify-api@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-1.0.0.tgz#50c377e3a121d149e5af8c10b1c54b0fbc64032e"
-  integrity sha512-WJDU6PYPeHbf6U7xSjvlvskUGF0gENAqV3/4mEd88xKivQOxPg0YsSqakcS7oDYlpKS0n0kOrv1gEx64BpyGlQ==
+"@shopify/shopify-api@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-1.1.0.tgz#81db856d7a9ce2d2cdc53ea8fca30d34d22521f5"
+  integrity sha512-V9hlLLuitOr1BdqhPfcID04wyC7AevMixDZA3XnARcCeSQUFtGRJnb72q0Zi0OnNtru18StFBRBMEm6RHj03zQ==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/jsonwebtoken" "^8.5.0"
@@ -1478,17 +1478,17 @@
   integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
 
 "@types/node-fetch@^2.5.7":
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
-  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
+  integrity sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==
   dependencies:
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.14.20":
-  version "14.14.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
-  integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
+"@types/node@*", "@types/node@^14.14.31":
+  version "14.14.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.31.tgz#72286bd33d137aa0d152d47ec7c1762563d34055"
+  integrity sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2745,9 +2745,9 @@ forever-agent@~0.6.1:
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
-  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -4096,17 +4096,17 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-db@1.45.0:
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
-  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
+mime-db@1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
+  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
 
 mime-types@^2.1.12:
-  version "2.1.28"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
-  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
+  version "2.1.29"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
+  integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
   dependencies:
-    mime-db "1.45.0"
+    mime-db "1.46.0"
 
 mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #58

We were not handling the OAuth callback properly for offline tokens because we always expected online sessions to be used.

### WHAT is this pull request doing?

Making sure that we allow offline mode both in `shopifyAuth` and `verifyRequest`.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
