### PR TITLE
Fix bad import path for type AccessMode

### DIFF
--- a/src/verify-request/types.ts
+++ b/src/verify-request/types.ts
@@ -1,4 +1,4 @@
-import { AccessMode } from "src/types";
+import { AccessMode } from "../types";
 
 export interface Routes {
   authRoute: string;


### PR DESCRIPTION
Fixes failing typescript runtime check due to bad import path.

```sh
src/node_modules/@shopify/koa-shopify-auth/dist/src/verify-request/types.d.ts:1:28 - error TS2307: Cannot find module 'src/types' or its corresponding type declarations.

1 import { AccessMode } from "src/types";
                             ~~~~~~~~~~~
Found 1 error.

```
