### PR TITLE
Fix: convert session.expires to Date first. Might be a string due to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+
+- Convert session.expires to a Date object. 
+
 ### Added
 
 ## [4.0.2] - 2021-03-03

--- a/src/verify-request/verify-token.ts
+++ b/src/verify-request/verify-token.ts
@@ -21,7 +21,7 @@ export function verifyToken(routes: Routes, accessMode: AccessMode = DEFAULT_ACC
     if (session) {
       const scopesChanged = !Shopify.Context.SCOPES.equals(session.scope);
 
-      if (!scopesChanged && session.accessToken && (!session.expires || session.expires >= new Date())) {
+      if (!scopesChanged && session.accessToken && (!session.expires || +(new Date(session.expires)) >= +(new Date()))) {
         ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
         await next();
         return;


### PR DESCRIPTION
…Redis seralization.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Expectation: `verifyRequest` should work out of the box.

Actual: `verifyRequest` redirects to the authRoute link even if the session has been successfully retrieved from the session store.

### WHAT is this pull request doing?

This fixes https://github.com/Shopify/koa-shopify-auth/issues/40

`session.expires` may not always be a Date object. When serialized and deserialized, it may return a string object. The comparison between `session.expires` and `new Date()` will have unexpected results.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
