### PR TITLE
Add option to return redirect URL as a header in verifyRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 ### Added
 
+- Add `returnHeader` option to `verifyRequest`, which allows using the middleware on XHR requests. [78](https://github.com/Shopify/koa-shopify-auth/pull/78)
+
 ## [4.0.3] - 2021-03-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ app.use(
     // which access mode is being used
     // defaults to 'online'
     accessMode: 'offline',
+    // if false, redirect the user to OAuth. If true, send back a 403 with the following headers:
+    //  - X-Shopify-API-Request-Failure-Reauthorize: '1'
+    //  - X-Shopify-API-Request-Failure-Reauthorize-Url: '<auth_url_path>'
+    // defaults to false
+    returnHeader: true,
   }),
 );
 ```

--- a/src/verify-request/types.ts
+++ b/src/verify-request/types.ts
@@ -7,6 +7,7 @@ export interface Routes {
 
 type VerifyRequestOptions = {
   accessMode: AccessMode;
+  returnHeader: boolean;
 }
 
 export type Options = Partial<VerifyRequestOptions> & Partial<Routes>;

--- a/src/verify-request/verify-request.ts
+++ b/src/verify-request/verify-request.ts
@@ -6,8 +6,9 @@ import {Options, Routes} from './types';
 import {DEFAULT_ACCESS_MODE} from '../auth';
 
 export default function verifyRequest(givenOptions: Options = {}) {
-  const {accessMode} = {
+  const {accessMode, returnHeader} = {
     accessMode: DEFAULT_ACCESS_MODE,
+    returnHeader: false,
     ...givenOptions
   };
   const routes: Routes = {
@@ -18,6 +19,6 @@ export default function verifyRequest(givenOptions: Options = {}) {
 
   return compose([
     loginAgainIfDifferentShop(routes, accessMode),
-    verifyToken(routes, accessMode)
+    verifyToken(routes, accessMode, returnHeader)
   ]);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-app-node/issues/575

Currently, the `verifyRequest` middleware will always return the code to redirect the user back to `/auth`, even if the request is not for a page. In those cases, we still want to fail the request, but we need the frontend to be able to pick up on this and trigger the OAuth flow.

### WHAT is this pull request doing?

This adds a `returnHeader` setting to `verifyRequest`, which will fail the request but return the necessary data for a redirect as a header, rather than the actual redirection code. That will allow the middleware to be used for both page loads and XHR requests.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
