### PR TITLE
Bumping shopify-api to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/Shopify/koa-shopify-auth/blob/master/README.md",
   "dependencies": {
     "@shopify/network": "^1.5.0",
-    "@shopify/shopify-api": "^1.2.0",
+    "@shopify/shopify-api": "^1.2.1",
     "koa-compose": ">=3.0.0 <4.0.0",
     "nonce": "^1.0.4",
     "tslib": "^1.9.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,10 +1257,10 @@
   dependencies:
     tslib "^1.14.1"
 
-"@shopify/shopify-api@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-1.2.0.tgz#f89aed782b4b359c0bff7a7a610e05648c1c9c68"
-  integrity sha512-/dw40VBJCS4mViNrI1kBJYp08FeNKgUDiUdt6nnbgioooLEdAEMHJq3uy1Qo9q3SraIsSOPVMjtqnCcKM0XHbg==
+"@shopify/shopify-api@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-1.2.1.tgz#dbe9944dd92dc8c77b2c96217e1cf923af94ceda"
+  integrity sha512-a2xNAQovf8WYGEAvjrdSK2bY3+XWuFgIfPhtxkO+QAMILb3dIk+Cxtbo1gaC1fD170AjwZ6gVl5RQbpe9ZVsfw==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/jsonwebtoken" "^8.5.0"


### PR DESCRIPTION
This PR just bumps the dependency on `@shopify/shopify-api` to v1.2.1 to support the new `April21` `ApiVersion`.