### PR TITLE
Remove usage of samesite=none for cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- Remove `samesite=none` setting from `cookie-options`. [83](https://github.com/Shopify/koa-shopify-auth/pull/83)
 ### Added
 
 ## [4.1.1] - 2021-03-26

--- a/src/auth/client/storage-access-helper.ts
+++ b/src/auth/client/storage-access-helper.ts
@@ -33,7 +33,7 @@ const storageAccessHelper = `(function() {
         window.location.href = this.redirectData.appTargetUrl;
       }
 
-      StorageAccessHelper.prototype.sameSiteNoneIncompatible = function(ua) {
+      StorageAccessHelper.prototype.secureIncompatible = function(ua) {
         return ua.includes("iPhone OS 12_") || ua.includes("iPad; CPU OS 12_") || //iOS 12
         (ua.includes("UCBrowser/")
             ? this.isOlderUcBrowser(ua) //UC Browser < 12.13.2
@@ -56,8 +56,8 @@ const storageAccessHelper = `(function() {
       }
 
       StorageAccessHelper.prototype.setCookie = function(value) {
-        if(!this.sameSiteNoneIncompatible(navigator.userAgent)) {
-          value += '; secure; SameSite=None'
+        if(!this.secureIncompatible(navigator.userAgent)) {
+          value += '; secure'
         }
         document.cookie = value;
       }

--- a/src/auth/cookie-options.ts
+++ b/src/auth/cookie-options.ts
@@ -7,7 +7,6 @@ export default function getCookieOptions(ctx: Context) {
   let cookieOptions = {};
   if (isChrome) {
     cookieOptions = {
-      sameSite: 'none',
       secure: true,
     };
   }

--- a/src/auth/test/cookie-options.test.ts
+++ b/src/auth/test/cookie-options.test.ts
@@ -13,7 +13,6 @@ describe('Get cookie options', () => {
     });
     const options = getCookieOptions(ctx);
     expect(options).toStrictEqual({
-      sameSite: 'none',
       secure: true,
     });
   });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #81 <!-- link to issue if one exists -->

The top level oauth cookie was set to `samesite=none` causing it to be treated as a 3rd party cookie during app review.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes all usage of `samesite=none` behavior for cookies. 
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
