### PR TITLE
fix request used to check oauth

### DIFF
--- a/src/verify-request/tests/verify-request.test.ts
+++ b/src/verify-request/tests/verify-request.test.ts
@@ -1,7 +1,6 @@
 import '../../test/test_helper';
 
 import {createMockContext} from '@shopify/jest-koa-mocks';
-import {StatusCode} from '@shopify/network';
 import Shopify, { RequestReturn } from '@shopify/shopify-api';
 import jwt from 'jsonwebtoken';
 
@@ -9,7 +8,6 @@ import verifyRequest from '../verify-request';
 import {clearSession} from '../utilities';
 import {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} from '../../index';
 import {REAUTH_HEADER, REAUTH_URL_HEADER} from '../verify-token';
-import { clear } from 'console';
 const TEST_SHOP = 'testshop.myshopify.io';
 const TEST_USER = '1';
 
@@ -41,10 +39,9 @@ describe('verifyRequest', () => {
       session.scope = 'test_scope';
       await Shopify.Utils.storeSession(session);
       
-      // mocking metafields call from client.get()
-      Shopify.Clients.Rest.prototype.get = jest.fn(({path, query}) => {
-        expect(path).toEqual('metafields');
-        expect(query).toEqual({'limit': 1})
+      // mocking shop call from client.get()
+      Shopify.Clients.Rest.prototype.get = jest.fn(({path}) => {
+        expect(path).toEqual('shop');
         return Promise.resolve({ "body": "" } as RequestReturn);
       });
     });

--- a/src/verify-request/verify-token.ts
+++ b/src/verify-request/verify-token.ts
@@ -29,7 +29,7 @@ export function verifyToken(routes: Routes, accessMode: AccessMode = DEFAULT_ACC
         try {
           // make a request to make sure oauth has succeeded, retry otherwise
           const client = new Shopify.Clients.Rest(session.shop, session.accessToken)
-          await client.get({ path: "metafields", query: {'limit': 1} }) 
+          await client.get({path: 'shop'});
 
           ctx.cookies.set(TOP_LEVEL_OAUTH_COOKIE_NAME);
           await next();


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #118 <!-- link to issue if one exists -->

We were using a call to the metafields endpoint to verify the oauth token was correct. Unfortunately that call has been deprecated so this solution should resolve the app verification issues.

### WHAT is this pull request doing?

This changes the path to the longer lived shop endpoint to solve our short-term issues.

@paulomarg @mllemango do we have an endpoint that's just a heartbeat / session check? I think this could be improved if we did.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
